### PR TITLE
chore(adapters): Add paginate to get partitions

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -97,7 +97,7 @@ class AthenaAdapter(SQLAdapter):
             TableName=table_name,
             Expression=where_condition,
         )
-        partitions = partition_pg.build_full_result().get("Partitions")
+        partitions = partition_pg.build_full_result()
         
         p = re.compile("s3://([^/]*)/(.*)")
         for partition in partitions["Partitions"]:

--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -90,12 +90,15 @@ class AthenaAdapter(SQLAdapter):
             glue_client = boto3_session.client("glue")
 
         s3_resource = boto3_session.resource("s3")
-        partitions = glue_client.get_partitions(
+        paginator = glue_client.get_paginator("get_partitions")
+        partition_pg = paginator.paginate(
             # CatalogId='123456789012', # Need to make this configurable if it is different from default AWS Account ID
             DatabaseName=database_name,
             TableName=table_name,
             Expression=where_condition,
         )
+        partitions = partition_pg.build_full_result().get("Partitions")
+        
         p = re.compile("s3://([^/]*)/(.*)")
         for partition in partitions["Partitions"]:
             logger.debug(


### PR DESCRIPTION
**Context:** Boto3 Glue client skip deleting of some partitions during incremental build in `insert_overwrite` mode, because Glue catalog now use pagination in API so large number of partitions will be distributed on different page.  And the current code is only for the first page.

**Update:** Add a paginator to go through all page to get the partition.